### PR TITLE
Update wget URL in action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,9 +30,9 @@ outputs:
 runs:
   using: "composite"
   steps: 
-    - run: wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip
+    - run: wget https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-amd64.tgz
       shell: bash
-    - run: unzip -qq ngrok-stable-linux-amd64.zip
+    - run: tar -xzf ngrok-v3-stable-linux-amd64.tgz
       shell: bash
     - run: ./ngrok authtoken ${{ inputs.ngrok_authtoken }}
       shell: bash


### PR DESCRIPTION
Update the wget URL in the `action.yml` file to the new ngrok URL.

* Change the wget URL from https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip to https://bin.equinox.io/c/bNyj1mQVY4c/ngrok-v3-stable-linux-amd64.tgz
* Update the run command to use tar instead of unzip for extracting the downloaded file

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/msgadi/ngrok-tunnel-action/pull/1?shareId=0f8d5c78-b1ab-43c0-b102-35b648c4ecca).